### PR TITLE
Fix missing trailing newline during load from file

### DIFF
--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -28,6 +28,8 @@ Document::Document(std::string filePath)
         {
             lines.push_back(line);
         }
+
+        lines.push_back(line);
     }
     else
     {


### PR DESCRIPTION
Fixed a missing trailing newline when loading an existing document from file.