### PR TITLE
Fixed duplicate last line during load

### DIFF
--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -29,7 +29,10 @@ Document::Document(std::string filePath)
             lines.push_back(line);
         }
 
-        lines.push_back(line);
+        if (line.empty())
+        {
+            lines.push_back(line);
+        }
     }
     else
     {


### PR DESCRIPTION
Fixed a duplicate last line during document load if a trailing newline wasn't found.