### PR TITLE
Fixed page up wrap around

### DIFF
--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -206,11 +206,13 @@ void Document::moveCursorRight()
 
 void Document::movePageUp(SDL_Point bounds)
 {
-    cursorY -= bounds.y;
-
-    if (cursorY < 0)
+    if (cursorY < (size_t) bounds.y)
     {
         cursorY = 0;
+    }
+    else
+    {
+        cursorY -= bounds.y;
     }
 
     cursorX = std::min(memory, lines[cursorY].length());


### PR DESCRIPTION
Fixed page up action causing the cursor to wrap around to the top end of size_t.